### PR TITLE
Add charset option to handle encoded strings

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+        - Add charset option in ::Digest to handle non-ASCII strings, RT#127553 (rrwo)
 0.00015 2016-06-01
         - Build fixes
 0.00014 2016-05-31

--- a/t/digest_sha.t
+++ b/t/digest_sha.t
@@ -1,8 +1,10 @@
+use utf8;
 use strict;
 use warnings;
 use Test::More;
 
 use Dir::Self;
+use Encode qw/ str2bytes /;
 use File::Spec;
 use File::Temp 'tempdir';
 use lib File::Spec->catdir(__DIR__, 'lib');
@@ -11,7 +13,7 @@ use DigestTest::Schema;
 
 BEGIN {
   if( eval 'require Digest' && eval 'require Digest::SHA' ){
-    plan tests => 25;
+    plan tests => 38;
   } else {
     plan skip_all => 'Digest::SHA not available';
     exit;
@@ -25,6 +27,8 @@ my $db_file = File::Spec->catfile($tmp, 'testdb.sqlite');
 my $schema = DigestTest::Schema->connect("dbi:SQLite:dbname=${db_file}");
 $schema->deploy({}, File::Spec->catdir(__DIR__, 'var'));
 
+my @test_values = qw( test1 test2 テスト );
+
 my $checks = {};
 for my $algorithm( qw/SHA-1 SHA-256/){
   my $maker = Digest->new($algorithm);
@@ -33,58 +37,63 @@ for my $algorithm( qw/SHA-1 SHA-256/){
     my $values = $encodings->{$encoding} = {};
     my $encoding_method = $encoding eq 'binary' ? 'digest' :
       ($encoding eq 'hex' ? 'hexdigest' : 'b64digest');
-    for my $value (qw/test1 test2/){
-      $maker->add($value);
+    for my $value (@test_values){
+      $maker->add(str2bytes("utf-8", $value));
       $values->{$value} = $maker->$encoding_method;
     }
   }
 }
 
+my $str = shift @test_values;
 
-my %create_values = map { $_ => 'test1' }
+my %create_values = map { $_ => $str }
   qw( dummy_col sha1_hex sha1_b64 sha256_hex sha256_b64 sha256_b64_salted );
 
 my $row = $schema->resultset('SHA')->create( \%create_values );
-is($row->dummy_col,  'test1','dummy on create');
+is($row->dummy_col,  $str,'dummy on create');
 ok(!$row->can('check_dummy_col'), 'no "check_dummy_col" method');
 
-is($row->sha1_hex,   $checks->{'SHA-1'}{hex}{test1},     'hex sha1 on create');
-is($row->sha1_b64,   $checks->{'SHA-1'}{base64}{test1},  'b64 sha1 on create');
-is($row->sha256_hex, $checks->{'SHA-256'}{hex}{test1},   'hex sha256 on create');
-is($row->sha256b64,  $checks->{'SHA-256'}{base64}{test1},'b64 sha256 on create');
+is($row->sha1_hex,   $checks->{'SHA-1'}{hex}{$str},     'hex sha1 on create');
+is($row->sha1_b64,   $checks->{'SHA-1'}{base64}{$str},  'b64 sha1 on create');
+is($row->sha256_hex, $checks->{'SHA-256'}{hex}{$str},   'hex sha256 on create');
+is($row->sha256b64,  $checks->{'SHA-256'}{base64}{$str},'b64 sha256 on create');
 is( length($row->sha256_b64_salted), 57, 'correct salted length');
 
 can_ok($row, qw/check_sha1_hex check_sha1_b64/);
-ok($row->check_sha1_hex('test1'),'Checking hex digest_check_method');
-ok($row->check_sha1_b64('test1'),'Checking b64 digest_check_method');
-ok($row->check_sha256_b64_salted('test1'), 'Checking salted digest_check_method');
+ok($row->check_sha1_hex($str),'Checking hex digest_check_method');
+ok($row->check_sha1_b64($str),'Checking b64 digest_check_method');
+ok($row->check_sha256_b64_salted($str), 'Checking salted digest_check_method');
 
-$row->sha1_hex('test2');
-is($row->sha1_hex, $checks->{'SHA-1'}{hex}{test2}, 'Checking accessor');
+foreach my $str2 (@test_values) {
 
-$row->update({sha1_b64 => 'test2',  dummy_col => 'test2'});
-is($row->sha1_b64, $checks->{'SHA-1'}{base64}{test2}, 'Checking update');
-is($row->dummy_col,  'test2', 'dummy on update');
+    $row->sha1_hex($str2);
+    is($row->sha1_hex, $checks->{'SHA-1'}{hex}{$str2}, 'Checking accessor');
 
-$row->set_column(sha256_hex => 'test2');
-is($row->sha256_hex, $checks->{'SHA-256'}{hex}{test2}, 'Checking set_column');
+    $row->update({sha1_b64 => $str2,  dummy_col => $str2});
+    is($row->sha1_b64, $checks->{'SHA-1'}{base64}{$str2}, 'Checking update');
+    is($row->dummy_col,  $str2, 'dummy on update');
 
-$row->sha256b64('test2');
-is($row->sha256b64, $checks->{'SHA-256'}{base64}{test2}, 'custom accessor');
+    $row->set_column(sha256_hex => $str2);
+    is($row->sha256_hex, $checks->{'SHA-256'}{hex}{$str2}, 'Checking set_column');
 
-$row->update;
+    $row->sha256b64($str2);
+    is($row->sha256b64, $checks->{'SHA-256'}{base64}{$str2}, 'custom accessor');
 
-my $copy = $row->copy({sha256_b64 => 'test2'});
-is($copy->sha1_hex,   $checks->{'SHA-1'}{hex}{test2},     'hex sha1 on copy');
-is($copy->sha1_b64,   $checks->{'SHA-1'}{base64}{test2},  'b64 sha1 on copy');
-is($copy->sha256_hex, $checks->{'SHA-256'}{hex}{test2},   'hex sha256 on copy');
-is($copy->sha256b64,  $checks->{'SHA-256'}{base64}{test2},'b64 sha256 on copy');
+    $row->update;
 
-my $new = $schema->resultset('SHA')->new( \%create_values );
-is($new->sha1_hex,   $checks->{'SHA-1'}{hex}{test1},      'hex sha1 on new');
-is($new->sha1_b64,   $checks->{'SHA-1'}{base64}{test1},   'b64 sha1 on new');
-is($new->sha256_hex, $checks->{'SHA-256'}{hex}{test1},    'hex sha256 on new');
-is($new->sha256b64,  $checks->{'SHA-256'}{base64}{test1}, 'b64 sha256 on new');
+    my $copy = $row->copy({sha256_b64 => $str2});
+    is($copy->sha1_hex,   $checks->{'SHA-1'}{hex}{$str2},     'hex sha1 on copy');
+    is($copy->sha1_b64,   $checks->{'SHA-1'}{base64}{$str2},  'b64 sha1 on copy');
+    is($copy->sha256_hex, $checks->{'SHA-256'}{hex}{$str2},   'hex sha256 on copy');
+    is($copy->sha256b64,  $checks->{'SHA-256'}{base64}{$str2},'b64 sha256 on copy');
+
+    my $new = $schema->resultset('SHA')->new( \%create_values );
+    is($new->sha1_hex,   $checks->{'SHA-1'}{hex}{$str},      'hex sha1 on new');
+    is($new->sha1_b64,   $checks->{'SHA-1'}{base64}{$str},   'b64 sha1 on new');
+    is($new->sha256_hex, $checks->{'SHA-256'}{hex}{$str},    'hex sha256 on new');
+    is($new->sha256b64,  $checks->{'SHA-256'}{base64}{$str}, 'b64 sha256 on new');
+
+}
 
 $row->sha1_hex(undef);
 $row->update;

--- a/t/lib/DigestTest/Schema/SHA.pm
+++ b/t/lib/DigestTest/Schema/SHA.pm
@@ -19,6 +19,7 @@ __PACKAGE__->add_columns(
     encode_column => 0,
     encode_class  => 'Digest',
     encode_check_method => 'check_dummy_col',
+    encode_args => { charset => 'utf-8' },
   },
   sha1_hex => {
     data_type => 'char',
@@ -29,6 +30,7 @@ __PACKAGE__->add_columns(
     encode_args => {
       format    => 'hex',
       algorithm => 'SHA-1',
+      charset => 'utf-8',
     },
     encode_check_method => 'check_sha1_hex',
   },
@@ -40,6 +42,7 @@ __PACKAGE__->add_columns(
     encode_class  => 'Digest',
     encode_args => {
       algorithm => 'SHA-1',
+      charset => 'utf-8',
     },
     encode_check_method => 'check_sha1_b64',
   },
@@ -49,7 +52,7 @@ __PACKAGE__->add_columns(
     size      => 64,
     encode_column => 1,
     encode_class  => 'Digest',
-    encode_args => { format => 'hex',},
+    encode_args => { format => 'hex', charset => 'utf-8', },
   },
   sha256_b64 => {
     data_type => 'char',
@@ -58,6 +61,7 @@ __PACKAGE__->add_columns(
     accessor  => 'sha256b64',
     encode_column => 1,
     encode_class  => 'Digest',
+    encode_args => { charset => 'utf-8' },
   },
   sha256_b64_salted => {
     data_type => 'char',
@@ -66,7 +70,7 @@ __PACKAGE__->add_columns(
     encode_column => 1,
     encode_class  => 'Digest',
     encode_check_method => 'check_sha256_b64_salted',
-    encode_args   => {salt_length => 14}
+    encode_args   => {salt_length => 14, charset => 'utf-8', }
   },
 );
 


### PR DESCRIPTION
This fixes [RT 127553](https://rt.cpan.org/Public/Bug/Display.html?id=127553) by adding an encode option, so that UTF-8 passwords can be supported.

It also updates tests accordingly.